### PR TITLE
Fixed protocol+port other than default on client side

### DIFF
--- a/usr/share/openmediavault/engined/rpc/openvpn.inc
+++ b/usr/share/openmediavault/engined/rpc/openvpn.inc
@@ -514,11 +514,14 @@ class OMVRpcServiceOpenVpn extends OMVRpcServiceAbstract
     {
         $commonName = $client["common_name"];
         $publicAddress = $settings["public_address"];
+        $port = $settings["port"];
+        $protocol = $settings["protocol"];
         $compression = empty($settings["compression"]) ? ";comp-lzo" : "comp-lzo";
 
         $conf = "";
         $conf .= "client\n";
-        $conf .= "remote $publicAddress\n";
+        $conf .= "remote $publicAddress $port\n";
+        $conf .= "proto $protocol\n";
         $conf .= "dev tun\n";
         $conf .= "ca   $commonName-ca.crt\n";
         $conf .= "cert $commonName-client.crt\n";


### PR DESCRIPTION
I just noticed that if user configures another port than default (1194), this is not passed to generated client config file. Same thing if user chooses TCP protocol instead of default protocol (UDP).
