### PR TITLE
Use interface from config.xml when looking up ip address for iptables…

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -40,8 +40,8 @@ case "$1" in
 
             omv_config_add_key "${SERVICE_XPATH}" "vpn_network" "10.8.0.0"
             omv_config_add_key "${SERVICE_XPATH}" "vpn_mask" "255.255.255.0"
-            omv_config_add_key "${SERVICE_XPATH}" "default_gateway" "1"
             omv_config_add_key "${SERVICE_XPATH}" "gateway_interface" ""
+            omv_config_add_key "${SERVICE_XPATH}" "default_gateway" "1"
             omv_config_add_key "${SERVICE_XPATH}" "client_to_client" "0"
 
             omv_config_add_key "${SERVICE_XPATH}" "dns" ""

--- a/debian/postinst
+++ b/debian/postinst
@@ -41,6 +41,7 @@ case "$1" in
             omv_config_add_key "${SERVICE_XPATH}" "vpn_network" "10.8.0.0"
             omv_config_add_key "${SERVICE_XPATH}" "vpn_mask" "255.255.255.0"
             omv_config_add_key "${SERVICE_XPATH}" "default_gateway" "1"
+            omv_config_add_key "${SERVICE_XPATH}" "gateway_interface" ""
             omv_config_add_key "${SERVICE_XPATH}" "client_to_client" "0"
 
             omv_config_add_key "${SERVICE_XPATH}" "dns" ""

--- a/usr/share/openmediavault/datamodels/conf.service.openvpn.json
+++ b/usr/share/openmediavault/datamodels/conf.service.openvpn.json
@@ -49,6 +49,10 @@
             "type": "boolean",
             "default": true
         },
+        "gateway_interface": {
+            "type": "string",
+            "default": true
+        },
         "client_to_client": {
             "type": "boolean",
             "default": false

--- a/usr/share/openmediavault/datamodels/conf.service.openvpn.json
+++ b/usr/share/openmediavault/datamodels/conf.service.openvpn.json
@@ -45,12 +45,12 @@
             "type": "string",
             "default": "255.255.255.0"
         },
-        "default_gateway": {
-            "type": "boolean",
-            "default": true
-        },
         "gateway_interface": {
             "type": "string",
+            "default": ""
+        },
+        "default_gateway": {
+            "type": "boolean",
             "default": true
         },
         "client_to_client": {

--- a/usr/share/openmediavault/datamodels/rpc.openvpn.json
+++ b/usr/share/openmediavault/datamodels/rpc.openvpn.json
@@ -45,6 +45,10 @@
                 "type": "boolean",
                 "required": true
             },
+            "gateway_interface": {
+                "type": "string",
+                "required": true
+            },
             "client_to_client": {
                 "type": "boolean",
                 "required": true

--- a/usr/share/openmediavault/datamodels/rpc.openvpn.json
+++ b/usr/share/openmediavault/datamodels/rpc.openvpn.json
@@ -41,12 +41,12 @@
                 "type": "string",
                 "required": true
             },
-            "default_gateway": {
-                "type": "boolean",
-                "required": true
-            },
             "gateway_interface": {
                 "type": "string",
+                "required": true
+            },
+            "default_gateway": {
+                "type": "boolean",
                 "required": true
             },
             "client_to_client": {

--- a/usr/share/openmediavault/mkconf/openvpn
+++ b/usr/share/openmediavault/mkconf/openvpn
@@ -32,18 +32,20 @@ SERVICE_OPENVPN_CONF="/etc/openvpn/server.conf"
 EASY_RSA_DIR="/usr/share/easy-rsa"
 EASY_RSA_KEY_DIR="${SERVICE_OPENVPN_KEY_DIR:-/etc/openvpn/keys}"
 
+get_ipv4_definition()
+{
+    local interface=$(xmlstarlet sel -t -v "//system/network/interfaces/interface[type='ethernet' or type='wireless'][1]/devicename" $OMV_CONFIG_FILE)
+    ifconfig $interface | grep 'inet addr:'
+}
+
 get_ip()
 {
-    local ip=$(ifconfig | grep 'inet addr:' | grep -v inet6 | grep -vE '127\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' | cut -d: -f2 | awk '{ print $1}' | head -1)
-
-    echo $ip
+    get_ipv4_definition | cut -d: -f2 | cut -d' ' -f1
 }
 
 get_mask()
 {
-    local mask=$(ifconfig | grep 'inet addr:' | grep -v inet6 | grep -vE '127\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' | cut -d: -f4 | awk '{ print $1}' | head -1)
-
-    echo $mask
+    get_ipv4_definition | cut -d: -f4 | cut -d' ' -f1
 }
 
 get_subnet()

--- a/usr/share/openmediavault/mkconf/openvpn
+++ b/usr/share/openmediavault/mkconf/openvpn
@@ -34,24 +34,23 @@ EASY_RSA_KEY_DIR="${SERVICE_OPENVPN_KEY_DIR:-/etc/openvpn/keys}"
 
 get_ipv4_definition()
 {
-    local interface=$(xmlstarlet sel -t -v "//system/network/interfaces/interface[type='ethernet' or type='wireless'][1]/devicename" $OMV_CONFIG_FILE)
-    ifconfig $interface | grep 'inet addr:'
+    ifconfig $1 | grep 'inet addr:'
 }
 
 get_ip()
 {
-    get_ipv4_definition | cut -d: -f2 | cut -d' ' -f1
+    get_ipv4_definition $1 | cut -d: -f2 | cut -d' ' -f1
 }
 
 get_mask()
 {
-    get_ipv4_definition | cut -d: -f4 | cut -d' ' -f1
+    get_ipv4_definition $1 | cut -d: -f4 | cut -d' ' -f1
 }
 
 get_subnet()
 {
-    local ip=$(get_ip)
-    local mask=$(get_mask)
+    local ip=$(get_ip $1)
+    local mask=$(get_mask $1)
     local IFS='.' subnet i
     local -a oct msk
     read -ra oct <<< "$ip"
@@ -108,9 +107,10 @@ setup_certificates()
 setup_config()
 {
     # Variables.
-    local ip=$(get_ip)
-    local mask=$(get_mask)
-    local subnet=$(get_subnet)
+    local gateway_interface=$(omv_config_get "$SERVICE_XPATH/gateway_interface")
+    local ip=$(get_ip $gateway_interface)
+    local mask=$(get_mask $gateway_interface)
+    local subnet=$(get_subnet $gateway_interface)
     local port=$(omv_config_get "$SERVICE_XPATH/port")
     local protocol=$(omv_config_get "$SERVICE_XPATH/protocol")
     local compression=$(omv_config_get "$SERVICE_XPATH/compression")

--- a/usr/share/openmediavault/mkconf/openvpn
+++ b/usr/share/openmediavault/mkconf/openvpn
@@ -34,23 +34,23 @@ EASY_RSA_KEY_DIR="${SERVICE_OPENVPN_KEY_DIR:-/etc/openvpn/keys}"
 
 get_ipv4_definition()
 {
-    ifconfig $1 | grep 'inet addr:'
+    ifconfig "$1" | grep "inet addr:"
 }
 
 get_ip()
 {
-    get_ipv4_definition $1 | cut -d: -f2 | cut -d' ' -f1
+    get_ipv4_definition "$1" | cut -d: -f2 | cut -d" " -f1
 }
 
 get_mask()
 {
-    get_ipv4_definition $1 | cut -d: -f4 | cut -d' ' -f1
+    get_ipv4_definition "$1" | cut -d: -f4 | cut -d" " -f1
 }
 
 get_subnet()
 {
-    local ip=$(get_ip $1)
-    local mask=$(get_mask $1)
+    local ip=$(get_ip "$1")
+    local mask=$(get_mask "$1")
     local IFS='.' subnet i
     local -a oct msk
     read -ra oct <<< "$ip"
@@ -108,9 +108,9 @@ setup_config()
 {
     # Variables.
     local gateway_interface=$(omv_config_get "$SERVICE_XPATH/gateway_interface")
-    local ip=$(get_ip $gateway_interface)
-    local mask=$(get_mask $gateway_interface)
-    local subnet=$(get_subnet $gateway_interface)
+    local ip=$(get_ip "$gateway_interface")
+    local mask=$(get_mask "$gateway_interface")
+    local subnet=$(get_subnet "$gateway_interface")
     local port=$(omv_config_get "$SERVICE_XPATH/port")
     local protocol=$(omv_config_get "$SERVICE_XPATH/protocol")
     local compression=$(omv_config_get "$SERVICE_XPATH/compression")

--- a/var/www/openmediavault/js/omv/module/admin/service/openvpn/Settings.js
+++ b/var/www/openmediavault/js/omv/module/admin/service/openvpn/Settings.js
@@ -138,6 +138,38 @@ Ext.define('OMV.module.admin.service.openvpn.Settings', {
                 allowBlank: false,
                 value: '255.255.255.0'
             }, {
+                xtype: 'combo',
+                name: 'gateway_interface',
+                fieldLabel: _('Gateway interface'),
+                store: Ext.create('OMV.data.Store', {
+                    autoLoad: true,
+                    model: OMV.data.Model.createImplicit({
+                        identifier: 'empty',
+                        idProperty: 'devicename',
+                        fields: [
+                            { name: 'devicename', type: 'string' },
+                        ]
+                    }),
+                    proxy: {
+                        type: 'rpc',
+                        rpcData: {
+                            service: 'Network',
+                            method: 'getInterfaceList'
+                        }
+                    },
+                    sorters: [{
+                        direction: 'ASC',
+                        property: 'devicename'
+                    }],
+
+                }),
+                emptyText: _('Select a device ...'),
+                displayField: 'devicename',
+                valueField: 'devicename',
+                allowBlank: false,
+                editable: false,
+                triggerAction: 'all',
+            }, {
                 xtype: 'checkbox',
                 name: 'default_gateway',
                 fieldLabel: _('Default gateway'),
@@ -146,38 +178,6 @@ Ext.define('OMV.module.admin.service.openvpn.Settings', {
                     ptype: 'fieldinfo',
                     text: _('If enabled, this directive will configure all clients to redirect their default network gateway through the VPN. If disabled, a static route to the private subnet is configured on all clients.')
                 }]
-            }, {
-                xtype: 'combo',
-                name: 'gateway_interface',
-                fieldLabel: _('Gateway Interface'),
-                store: Ext.create("OMV.data.Store", {
-                    autoLoad: true,
-                    model: OMV.data.Model.createImplicit({
-                        identifier: "empty",
-                        idProperty: "devicename",
-                        fields: [
-                            { name: "devicename", type: "string" },
-                        ]
-                    }),
-                    proxy: {
-                        type: "rpc",
-                        rpcData: {
-                            service: "Network",
-                            method: "getInterfaceList"
-                        }
-                    },
-                    sorters: [{
-                        direction: "ASC",
-                        property: "devicename"
-                    }],
-
-                }),
-                emptyText: _("Select a device ..."),
-                displayField: 'devicename',
-                valueField: 'devicename',
-                allowBlank: false,
-                editable: false,
-                triggerAction: 'all',
             }, {
                 xtype: 'checkbox',
                 name: 'client_to_client',

--- a/var/www/openmediavault/js/omv/module/admin/service/openvpn/Settings.js
+++ b/var/www/openmediavault/js/omv/module/admin/service/openvpn/Settings.js
@@ -17,10 +17,16 @@
 
 // require("js/omv/WorkspaceManager.js")
 // require("js/omv/workspace/form/Panel.js")
+// require("js/omv/Rpc.js")
+// require("js/omv/data/Store.js")
+// require("js/omv/data/Model.js")
+// require("js/omv/data/proxy/Rpc.js")
 
 Ext.define('OMV.module.admin.service.openvpn.Settings', {
     extend: 'OMV.workspace.form.Panel',
-
+    requires: [
+            "OMV.Rpc"
+    ],
     rpcService: 'OpenVpn',
     rpcGetMethod: 'getSettings',
     rpcSetMethod: 'setSettings',
@@ -140,6 +146,38 @@ Ext.define('OMV.module.admin.service.openvpn.Settings', {
                     ptype: 'fieldinfo',
                     text: _('If enabled, this directive will configure all clients to redirect their default network gateway through the VPN. If disabled, a static route to the private subnet is configured on all clients.')
                 }]
+            }, {
+                xtype: 'combo',
+                name: 'gateway_interface',
+                fieldLabel: _('Gateway Interface'),
+                store: Ext.create("OMV.data.Store", {
+                    autoLoad: true,
+                    model: OMV.data.Model.createImplicit({
+                        identifier: "empty",
+                        idProperty: "devicename",
+                        fields: [
+                            { name: "devicename", type: "string" },
+                        ]
+                    }),
+                    proxy: {
+                        type: "rpc",
+                        rpcData: {
+                            service: "Network",
+                            method: "getInterfaceList"
+                        }
+                    },
+                    sorters: [{
+                        direction: "ASC",
+                        property: "devicename"
+                    }],
+
+                }),
+                emptyText: _("Select a device ..."),
+                displayField: 'devicename',
+                valueField: 'devicename',
+                allowBlank: false,
+                editable: false,
+                triggerAction: 'all',
             }, {
                 xtype: 'checkbox',
                 name: 'client_to_client',

--- a/var/www/openmediavault/js/omv/module/admin/service/openvpn/Settings.js
+++ b/var/www/openmediavault/js/omv/module/admin/service/openvpn/Settings.js
@@ -25,7 +25,7 @@
 Ext.define('OMV.module.admin.service.openvpn.Settings', {
     extend: 'OMV.workspace.form.Panel',
     requires: [
-            "OMV.Rpc"
+            'OMV.Rpc'
     ],
     rpcService: 'OpenVpn',
     rpcGetMethod: 'getSettings',


### PR DESCRIPTION
I was running into issues with my docker0 ip address being used for the iptables rule. This patch uses the first ethernet/wifi interface from config.xml instead of just the first interface returned by ifconfig.