### PR TITLE
--ns-cert-type depreciated

### DIFF
--- a/usr/share/openmediavault/engined/rpc/openvpn.inc
+++ b/usr/share/openmediavault/engined/rpc/openvpn.inc
@@ -368,7 +368,7 @@ class OpenVpn extends ServiceAbstract
             'remote ' . $publicAddress . ' ' . $port,
             'proto ' . $protocol,
             'dev tun',
-            'ns-cert-type server',
+            'remote-cert-tls server',
             $compression,
             $pam_authentication,
             'persist-key',


### PR DESCRIPTION
> As of OpenSSL v1.1, the nsCertType extension in X.509 certificates are no longer supported. ... The replacement option, ---remote-cert-tls is a macro which sets the --remote-cert-ku and --remote-cert-eku to appropriate values, depending on it is wanted to check if the remote provided certificate is a server or client certificate. As the extended key usage extension is far more commonly used today, this is effectively the equivalent of --ns-cert-type.

https://community.openvpn.net/openvpn/wiki/DeprecatedOptions#a--ns-cert-type