### PR TITLE
enable server push route

### DIFF
--- a/usr/share/openmediavault/mkconf/openvpn
+++ b/usr/share/openmediavault/mkconf/openvpn
@@ -182,6 +182,7 @@ key "$EASY_RSA_KEY_DIR/private/$HOSTNAME.key" # This file should be kept secret
 dh "$EASY_RSA_KEY_DIR/dh.pem"
 topology subnet
 server $vpn_network $vpn_mask
+push "route $vpn_network $vpn_mask"
 ifconfig-pool-persist ipp.txt
 $static_route
 $default_gateway


### PR DESCRIPTION
Server will not allow clients to connect if push route is not enabled in the server conf, adding this line ensures that the script will write the push route with the correct params