### PR TITLE
updated postrm to remove openvpn

### DIFF
--- a/debian/postrm
+++ b/debian/postrm
@@ -36,6 +36,9 @@ case "$1" in
 
         # Remove the easyrsa directory
         rm -rf /opt/Easy-RSA-*
+        
+        # Uninstall openvpn
+        apt-get remove openvpn
     ;;
 
     remove)


### PR DESCRIPTION
Added extra line in postrm script when uninstalling the plugin the openvpn package will be removed from server, this will prevent errors when users delete /etc/openvpn folder from server and reinstall the openvpn plugin  (mkdir: cannot create directory ‘/etc/openvpn/pki)