### PR TITLE
Only keep one line on get_subnet

### DIFF
--- a/usr/share/openmediavault/mkconf/openvpn
+++ b/usr/share/openmediavault/mkconf/openvpn
@@ -61,7 +61,7 @@ get_mask()
 
 get_subnet()
 {
-    subnet=$(ip r s | grep -Ev "^default|^169\.254\." | grep ${1} | cut -d/ -f1)
+    subnet=$(ip r s | grep -Ev "^default|^169\.254\." | grep -m 1 ${1} | cut -d/ -f1)
     echo "${subnet}"
 }
 


### PR DESCRIPTION
On cases where the same interface has multiple routes (https://bbs.archlinux.org/viewtopic.php?id=185043) keep only the first result on `get_subnet` script.

https://github.com/OpenMediaVault-Plugin-Developers/openmediavault-openvpn/issues/24